### PR TITLE
Greatly improved compatibility by using bash

### DIFF
--- a/torch.sh
+++ b/torch.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 USAGE="Usage: torch [<OPTIONS>]
 
 Options:


### PR DESCRIPTION
On systems where `sh` isn't just a link to `bash`, using a sh shebang doesn't work. This changes it to explicitly use a bash shebang instead of a sh shebang, which improves compatibility with many linux distros.
